### PR TITLE
Log group cleanup

### DIFF
--- a/cloudformation/cfn-test-template.yml
+++ b/cloudformation/cfn-test-template.yml
@@ -58,6 +58,9 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${CfnTestFunction}
+    DependsOn:
+    # Hopefully this will prevent the log group from being deleted before the lambda function
+    - CfnTestFunction
   BadPasswordTest:
     Type: Custom::Test
     Properties:

--- a/cloudformation/cfn-test-template.yml
+++ b/cloudformation/cfn-test-template.yml
@@ -27,19 +27,17 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
         Ref: LambdaManagedPolicyArns
-      # Policies:
-      # - PolicyName: NoCreateLogGroups
-      #   PolicyDocument:
-      #     Version: "2012-10-17"
-      #     Statement:
+      Policies:
+      - PolicyName: NoCreateLogGroups
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
           # Don't allow Lambda function to re-create its groups while CloudFormation is
           # deleting the stack
-
-          # TODO: Is this really necessary?  Won't it work, since the custom resource depends on the log group?
-          # - Effect: Deny
-          #   Action:
-          #   - logs:CreateLogGroup
-          #   Resource: arn:aws:logs:*:*:*
+          - Effect: Deny
+            Action:
+            - logs:CreateLogGroup
+            Resource: arn:aws:logs:*:*:*
   CfnTestFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -58,9 +56,6 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${CfnTestFunction}
-    DependsOn:
-    # Hopefully this will prevent the log group from being deleted before the lambda function
-    - CfnTestFunction
   BadPasswordTest:
     Type: Custom::Test
     Properties:
@@ -71,7 +66,8 @@ Resources:
           - ","
           - Ref: TestParameters
     DependsOn:
-      CfnTestFunctionLogGroup
+    - LambdaExecutionRole
+    - CfnTestFunctionLogGroup
 # Outputs:
 #   CfnTestFunctionArn:
 #     Value:

--- a/cloudformation/githubstatustemplate.yml
+++ b/cloudformation/githubstatustemplate.yml
@@ -33,6 +33,9 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${GitHubStatusFunction}
+    DependsOn:
+    # Hopefully this will prevent the log group from being deleted before the lambda function
+    - GitHubStatusFunction
 Outputs:
   GitHubStatusFunctionArn:
     Value:

--- a/cloudformation/githubstatustemplate.yml
+++ b/cloudformation/githubstatustemplate.yml
@@ -17,6 +17,17 @@ Resources:
       Path: "/"
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AWSLambdaExecute
+      Policies:
+      - PolicyName: NoCreateLogGroups
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          # Don't allow Lambda function to re-create its groups while CloudFormation is
+          # deleting the stack
+          - Effect: Deny
+            Action:
+            - logs:CreateLogGroup
+            Resource: arn:aws:logs:*:*:*
   GitHubStatusFunction:
     Type: AWS::Lambda::Function
     Properties:
@@ -33,9 +44,6 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${GitHubStatusFunction}
-    DependsOn:
-    # Hopefully this will prevent the log group from being deleted before the lambda function
-    - GitHubStatusFunction
 Outputs:
   GitHubStatusFunctionArn:
     Value:

--- a/cloudformation/snsmessagecollectortemplate.yml
+++ b/cloudformation/snsmessagecollectortemplate.yml
@@ -114,6 +114,9 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${CollectorFunction}
+    DependsOn:
+    # Hopefully this will prevent the log group from being deleted before the lambda function
+    - CollectorFunction
   CountTable:
     Type: AWS::DynamoDB::Table
     Properties:

--- a/cloudformation/snsmessagecollectortemplate.yml
+++ b/cloudformation/snsmessagecollectortemplate.yml
@@ -67,18 +67,16 @@ Resources:
       ManagedPolicyArns:
       - arn:aws:iam::aws:policy/AWSLambdaExecute
       Policies:
-      # I don't think this is needed because the custom resource depends on the log group.
-      
-      # - PolicyName: NoCreateLogGroups
-      #   PolicyDocument:
-      #     Version: "2012-10-17"
-      #     Statement:
-      #     # Don't allow Lambda function to re-create its groups while CloudFormation is
-      #     # deleting the stack
-      #     - Effect: Deny
-      #       Action:
-      #       - logs:CreateLogGroup
-      #       Resource: arn:aws:logs:*:*:*
+      - PolicyName: NoCreateLogGroups
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          # Don't allow Lambda function to re-create its groups while CloudFormation is
+          # deleting the stack
+          - Effect: Deny
+            Action:
+            - logs:CreateLogGroup
+            Resource: arn:aws:logs:*:*:*
       - PolicyName: CountTableAccess
         PolicyDocument:
           Version: "2012-10-17"
@@ -114,9 +112,6 @@ Resources:
     Properties:
       LogGroupName:
         Fn::Sub: /aws/lambda/${CollectorFunction}
-    DependsOn:
-    # Hopefully this will prevent the log group from being deleted before the lambda function
-    - CollectorFunction
   CountTable:
     Type: AWS::DynamoDB::Table
     Properties:


### PR DESCRIPTION
Having the custom resources depend on the log groups doesn't seem to prevent the log groups from getting re-created during stack deletion.  Possibly because Lambda logs don't get written to CloudWatch right away?